### PR TITLE
Compilation fixes

### DIFF
--- a/src/antkeymapper.cpp
+++ b/src/antkeymapper.cpp
@@ -18,6 +18,7 @@
 //#include <QDebug>
 #include <QtGlobal>
 #include <QStringList>
+#include <cassert>
 
 #include "antkeymapper.h"
 #include "eventhandlerfactory.h"
@@ -90,11 +91,10 @@ AntKeyMapper* AntKeyMapper::getInstance(QString handler)
 {
     if (!_instance)
     {
+        assert(!handler.isEmpty());
         QStringList temp = buildEventGeneratorList();
-        if (!handler.isEmpty() && temp.contains(handler))
-        {
-            _instance = new AntKeyMapper(handler);
-        }
+        assert(temp.contains(handler));
+        _instance = new AntKeyMapper(handler);
     }
 
     return _instance;

--- a/src/antkeymapper.cpp
+++ b/src/antkeymapper.cpp
@@ -36,8 +36,12 @@ static QStringList buildEventGeneratorList()
   #endif
 
 #else
+  #ifdef WITH_XTEST
     temp.append("xtest");
+  #endif
+  #ifdef WITH_UINPUT
     temp.append("uinput");
+  #endif
 
 #endif
     return temp;

--- a/src/buttoneditdialog.cpp
+++ b/src/buttoneditdialog.cpp
@@ -17,6 +17,7 @@
 
 //#include <QDebug>
 #include <QtGlobal>
+#include <cassert>
 
 #ifdef Q_OS_WIN
 #include <qt_windows.h>
@@ -218,7 +219,9 @@ void ButtonEditDialog::keyReleaseEvent(QKeyEvent *event)
         {
             // Find Qt Key corresponding to X11 KeySym.
             //checkalias = x11KeyMapper.returnQtKey(finalvirtual);
+            assert(AntKeyMapper::getInstance()->hasNativeKeyMapper());
             QtKeyMapperBase *x11KeyMapper = AntKeyMapper::getInstance()->getNativeKeyMapper();
+            assert(x11KeyMapper!=NULL);
             checkalias = x11KeyMapper->returnQtKey(finalvirtual);
             // Find corresponding Linux input key for the Qt key.
             finalvirtual = AntKeyMapper::getInstance()->returnVirtualKey(checkalias);

--- a/src/eventhandlers/uinputeventhandler.h
+++ b/src/eventhandlers/uinputeventhandler.h
@@ -19,6 +19,7 @@
 #define UINPUTEVENTHANDLER_H
 
 #include "baseeventhandler.h"
+#include "../qtx11keymapper.h"
 
 #include <springmousemoveinfo.h>
 #include <joybuttonslot.h>

--- a/src/sdleventreader.cpp
+++ b/src/sdleventreader.cpp
@@ -191,7 +191,11 @@ int SDLEventReader::CheckForEvents()
     */
 
     SDL_PumpEvents();
+    #ifdef USE_SDL_2
     switch (SDL_PeepEvents(NULL, 1, SDL_GETEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT))
+    #else
+    switch (SDL_PeepEvents(NULL, 1, SDL_GETEVENT, 0xFFFF))
+    #endif
     {
         case -1:
         {


### PR DESCRIPTION
These changes allow compiling of:
-DWITH_UINPUT=ON -DWITH_XTEST=OFF -DUSE_SDL_2=OFF

This is for systems where SDL2 does not detect the controller.