### PR TITLE
cmake: Use CMake's X11 library variables instead of hardcoding them.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -570,12 +570,12 @@ endif(UNIX)
 
 if(UNIX)
     if(WITH_X11)
-        LIST(APPEND LIBS X11)
-        LIST(APPEND LIBS Xi)
+        LIST(APPEND LIBS ${X11_X11_LIB})
+        LIST(APPEND LIBS ${X11_Xi_LIB})
     endif(WITH_X11)
 
     if(WITH_XTEST)
-        LIST(APPEND LIBS Xtst)
+        LIST(APPEND LIBS ${X11_XTest_LIB})
     endif(WITH_XTEST)
 
     if(USE_SDL_2)


### PR DESCRIPTION
Hardcoding them is bad, as the linker will be passed something like
"-lfoo" instead of "/path/to/libfoo.so". The former only works if
libfoo.so's directory is in the linker's default search path.

Since `find_package(X11)` is already being called, just use the variables
CMake defines instead.